### PR TITLE
Add enum support for RandomProvider

### DIFF
--- a/core/src/main/kotlin/io/github/serpro69/kfaker/RandomService.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/RandomService.kt
@@ -23,6 +23,8 @@ internal class RandomService(private val random: Random) {
 
     fun <T> randomValue(list: List<T>) = list[nextInt(list.size)]
 
+    fun <T> randomValue(array: Array<T>) = array[nextInt(array.size)]
+
     fun nextLetter(upper: Boolean): Char {
         val source = if (upper) alphabeticSource.toUpperCase() else alphabeticSource
 

--- a/core/src/test/kotlin/io/github/serpro69/kfaker/RandomServiceTest.kt
+++ b/core/src/test/kotlin/io/github/serpro69/kfaker/RandomServiceTest.kt
@@ -61,6 +61,39 @@ internal class RandomServiceTest : DescribeSpec({
             }
         }
 
+        context("calling randomValue<T>(array)") {
+            context("array is not empty") {
+                val values = Array(100) { randomService.nextInt(3..9) }
+                val value = randomService.randomValue(values)
+
+                it("return value should be in the array") {
+                    values shouldContain value
+                }
+            }
+
+            context("array is empty") {
+                val values = arrayOf<String>()
+
+                it("exception is thrown") {
+                    shouldThrow<IllegalArgumentException> {
+                        randomService.randomValue(values)
+                    }
+                }
+            }
+
+            context("array contains nulls") {
+                val values = arrayOf(1, 2, 3, null).filter { it == null }
+                val value = randomService.randomValue(values)
+
+                it("return value should be in the array") {
+                    assertSoftly {
+                        values shouldContain value
+                        value shouldBe null
+                    }
+                }
+            }
+        }
+
         context("calling nextChar()") {
             val source = "qwertyuiopasdfghjklzxcvbnm"
 

--- a/core/src/test/kotlin/io/github/serpro69/kfaker/provider/RandomProviderTest.kt
+++ b/core/src/test/kotlin/io/github/serpro69/kfaker/provider/RandomProviderTest.kt
@@ -109,4 +109,22 @@ class RandomProviderTest : DescribeSpec({
             }
         }
     }
+
+    describe("a TestClass with non-empty constructor with enum type") {
+        class TestClass(val enum: TestEnum)
+
+        context("creating a random instance of the class") {
+            val testClass: TestClass = randomProvider.randomClassInstance()
+
+            it("it should be instance of TestClass") {
+                testClass shouldBe instanceOf(TestClass::class)
+            }
+        }
+    }
 })
+
+enum class TestEnum {
+    KOTLIN,
+    JAVA,
+    GO
+}


### PR DESCRIPTION
Add support for enum parameters to RandomService

If I get positive feedback for this pull request, I will try to add array as I need them for my use case.