### PR TITLE
Add nullable types to random provider type generator

### DIFF
--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/RandomProvider.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/RandomProvider.kt
@@ -158,8 +158,7 @@ class RandomProviderConfig @PublishedApi internal constructor() {
     /**
      * Configures generation for a specific nullable type. It can override internal generators (for primitives, for example)
      */
-    @JvmName("typeGenerator_null")
-    inline fun <reified K : Any?> typeGenerator(noinline generator: () -> K?) {
+    inline fun <reified K : Any?> nullableTypeGenerator(noinline generator: () -> K?) {
         nullableGenerators[K::class] = generator
     }
 }

--- a/core/src/test/kotlin/io/github/serpro69/kfaker/provider/RandomProviderTest.kt
+++ b/core/src/test/kotlin/io/github/serpro69/kfaker/provider/RandomProviderTest.kt
@@ -173,7 +173,8 @@ class RandomProviderTest : DescribeSpec({
             val testClass: TestClass = randomProvider.randomClassInstance {
                 @Suppress("RemoveExplicitTypeArguments")
                 typeGenerator<UUID> { givenUuid }
-                typeGenerator<Int?> { givenInt }
+                @Suppress("RemoveExplicitTypeArguments")
+                typeGenerator<Int> { givenInt } // use the not-null type generator and verify it is used for Int?
                 typeGenerator<Long?> { givenNullableLong }
                 @Suppress("RemoveExplicitTypeArguments")
                 typeGenerator<Long> { givenLong }

--- a/core/src/test/kotlin/io/github/serpro69/kfaker/provider/RandomProviderTest.kt
+++ b/core/src/test/kotlin/io/github/serpro69/kfaker/provider/RandomProviderTest.kt
@@ -175,7 +175,7 @@ class RandomProviderTest : DescribeSpec({
                 typeGenerator<UUID> { givenUuid }
                 @Suppress("RemoveExplicitTypeArguments")
                 typeGenerator<Int> { givenInt } // use the not-null type generator and verify it is used for Int?
-                typeGenerator<Long?> { givenNullableLong }
+                nullableTypeGenerator<Long?> { givenNullableLong }
                 @Suppress("RemoveExplicitTypeArguments")
                 typeGenerator<Long> { givenLong }
             }

--- a/core/src/test/kotlin/io/github/serpro69/kfaker/provider/RandomProviderTest.kt
+++ b/core/src/test/kotlin/io/github/serpro69/kfaker/provider/RandomProviderTest.kt
@@ -154,6 +154,44 @@ class RandomProviderTest : DescribeSpec({
         }
     }
 
+    describe("a TestClass with non-empty constructor for nullable custom type generators") {
+        class Foo(val int: Int?)
+        class TestClass(
+            val id: UUID,
+            val int: Int?,
+            val nullableLong: Long?,
+            val notNullLong: Long,
+            val foo: Foo
+        )
+
+        val givenUuid = UUID.fromString("00000000-0000-0000-0000-000000000000")
+        val givenInt = 1
+        val givenNullableLong: Long? = null
+        val givenLong = 1L
+
+        context("creating a random instance of the class with nullable custom generators") {
+            val testClass: TestClass = randomProvider.randomClassInstance {
+                @Suppress("RemoveExplicitTypeArguments")
+                typeGenerator<UUID> { givenUuid }
+                typeGenerator<Int?> { givenInt }
+                typeGenerator<Long?> { givenNullableLong }
+                @Suppress("RemoveExplicitTypeArguments")
+                typeGenerator<Long> { givenLong }
+            }
+
+            it("it should be a predefined UUID and primitives with nulls") {
+                assertSoftly {
+                    testClass shouldBe instanceOf(TestClass::class)
+                    testClass.id shouldBe givenUuid
+                    testClass.int shouldBe givenInt
+                    testClass.nullableLong shouldBe givenNullableLong
+                    testClass.notNullLong shouldBe givenLong
+                    testClass.foo.int shouldBe givenInt
+                }
+            }
+        }
+    }
+
     describe("a TestClass with 3 non-default constructors") {
 
         class Foo


### PR DESCRIPTION
adds the ability to create nullable explicitly set to null via the random type generator via `nullableTypeGenerator`

this also allows you to set one for `typeGenerator<T>` and another for `nullableTypeGenerator<T?>` if you wanted separate values but if you specify `typeGenerator<T>` and not `nullableTypeGenerator<T?>` then it will default to the not-null value for any `<T>`
so:
```
class Foo(val int: Int?)

randomProvider.randomClassInstance<Foo> {
	typeGenerator<Int> { 3 }
}.int == 3

randomProvider.randomClassInstance<Foo>{
	nullableTypeGenerator<Int?> { 3 } 
}.int == 3

randomProvider.randomClassInstance<Foo>{
	nullableTypeGenerator<Int?> { null } 
}.int == null

randomProvider.randomClassInstance<Foo>{
	  typeGenerator<Int> { 3 } 	
	  nullableTypeGenerator<Int?> { null } 
}.int == null

```
