### PR TITLE
Create Faker dsl for easier configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
     - [Generating data](#generating-data)
     - [Configuring Faker](#configuring-faker)
         - [Default configuration](#default-configuration)
+        - [Using Kotlin DSL](#using-kotlin-dsl)
         - [Deterministic Random](#deterministic-random)
         - [Generating unique values](#generating-unique-values)
         - [Localized dictionary](#localized-dictionary)
@@ -123,6 +124,20 @@ If no `FakerConfig` instance is passed to `Faker` constructor then default confi
 - `locale` is set to `en`
 - `random` is seeded with a pseudo-randomly generated number.
 - `uniqueGeneratorRetryLimit` is set to `100`
+
+#### Using Kotlin DSL
+
+Faker can use Kotlin DSL to create and configure Faker instances
+
+```kotlin
+val faker = faker { 
+    config { 
+        random = Random()
+        locale = "nl"
+        uniqueGeneratorRetryLimit = 111
+    }
+}
+```
 
 #### Deterministic Random
 

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/Faker.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/Faker.kt
@@ -369,4 +369,17 @@ class Faker @JvmOverloads constructor(internal val fakerConfig: FakerConfig = Fa
         yoda = Yoda(fakerService)
         zelda = Zelda(fakerService)
     }
+
+    @FakerDsl
+    class Builder {
+        private var config = fakerConfig { }
+
+        fun config(block: FakerConfig.Builder.() -> Unit) {
+            this.config = fakerConfig(block)
+        }
+
+        fun build() = Faker(config)
+    }
 }
+
+fun faker(block: Faker.Builder.() -> Unit) = Faker.Builder().apply(block).build()

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/FakerConfig.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/FakerConfig.kt
@@ -15,6 +15,7 @@ class FakerConfig private constructor(
         fun builder() = Builder()
     }
 
+    @FakerDsl
     class Builder internal constructor() {
         var locale = "en"
         var random = Random()
@@ -29,3 +30,5 @@ class FakerConfig private constructor(
 }
 
 fun FakerConfig.Builder.create(block: FakerConfig.Builder.() -> Unit) = this.apply(block).build()
+
+fun fakerConfig(block: FakerConfig.Builder.() -> Unit) = FakerConfig.Builder().apply(block).build()

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/FakerDsl.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/FakerDsl.kt
@@ -1,0 +1,3 @@
+package io.github.serpro69.kfaker
+
+@DslMarker annotation class FakerDsl


### PR DESCRIPTION
I've created a DSL to create `Faker` instances.

So instead of having to do something like this:

```kotlin
val fakerConfig = FakerConfig.builder().create {
    random = Random(42)
}

val faker = Faker(fakerConfig)
```

We can now do this:


```kotlin
val faker = faker {
    config {
        random = Random()
        locale = "nl"
        uniqueGeneratorRetryLimit = 111
    }
}
```

A bit more concise and the Kotlin way. 