### PR TITLE
Fix deprecation warnings intruduced with kotlin 1.5.0

### DIFF
--- a/cli-bot/src/main/kotlin/io/github/serpro69/kfaker/app/cli/Renderer.kt
+++ b/cli-bot/src/main/kotlin/io/github/serpro69/kfaker/app/cli/Renderer.kt
@@ -86,7 +86,7 @@ fun renderProvider(
     }
 
     return if (options.javaSyntax) {
-        val getterName = "get${provider.name.first().toUpperCase()}${provider.name.substring(1)}()"
+        val getterName = "get${provider.name.first().uppercase()}${provider.name.substring(1)}()"
         Renderer(getterName, renderedFunctions)
     } else {
         Renderer(provider.name, renderedFunctions)

--- a/cli-bot/src/main/kotlin/io/github/serpro69/kfaker/app/subcommands/List.kt
+++ b/cli-bot/src/main/kotlin/io/github/serpro69/kfaker/app/subcommands/List.kt
@@ -44,7 +44,7 @@ object List : Runnable {
 
         val renderedProviders = if (providerNames.isNotEmpty()) {
             introspector.providerFunctions.filter { (provider, _) ->
-                providerNames.any { provider.name.toLowerCase().contains(it.toLowerCase() ) }
+                providerNames.any { provider.name.lowercase().contains(it.lowercase() ) }
             }.map { (provider, functions) ->
                 renderProvider(options, faker, provider, functions)
             }

--- a/cli-bot/src/main/kotlin/io/github/serpro69/kfaker/app/subcommands/Lookup.kt
+++ b/cli-bot/src/main/kotlin/io/github/serpro69/kfaker/app/subcommands/Lookup.kt
@@ -38,7 +38,7 @@ object Lookup : Runnable {
         val introspector = Introspector(faker)
 
         val filteredMap = introspector.providerFunctions.mapValuesTo(mutableMapOf()) { (_, v) ->
-            v.filter { it.name.toLowerCase().contains(functionName.toLowerCase()) }
+            v.filter { it.name.lowercase().contains(functionName.lowercase()) }
         }.filterValues { it.isNotEmpty() }
 
         val renderedProviders = filteredMap.map { (provider, functions) ->

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/FakerService.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/FakerService.kt
@@ -414,7 +414,7 @@ internal class FakerService @JvmOverloads internal constructor(
      */
     private fun <T : FakeDataProvider> T.getFunctionName(rawString: String): KFunction<*> {
         val propertyName = rawString.split("_").mapIndexed { i: Int, s: String ->
-            if (i == 0) s else s.substring(0, 1).toUpperCase() + s.substring(1)
+            if (i == 0) s else s.substring(0, 1).uppercase() + s.substring(1)
         }.joinToString("")
 
         return this::class.declaredFunctions.first { it.name == propertyName }
@@ -425,7 +425,7 @@ internal class FakerService @JvmOverloads internal constructor(
      */
     private fun getProvider(simpleClassName: String): FakeDataProvider {
         val kProp = faker::class.declaredMemberProperties.first {
-            it.name.toLowerCase() == simpleClassName.toLowerCase()
+            it.name.lowercase() == simpleClassName.lowercase()
         }
 
         return kProp.call(faker) as FakeDataProvider

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/RandomService.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/RandomService.kt
@@ -26,7 +26,7 @@ class RandomService internal constructor(private val random: Random) {
     fun <T> randomValue(array: Array<T>) = array[nextInt(array.size)]
 
     fun nextLetter(upper: Boolean): Char {
-        val source = if (upper) alphabeticSource.toUpperCase() else alphabeticSource
+        val source = if (upper) alphabeticSource.uppercase() else alphabeticSource
 
         return source[nextInt(source.length)]
     }

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/dictionary/Dictionary.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/dictionary/Dictionary.kt
@@ -174,7 +174,8 @@ internal enum class CategoryName {
 }
 
 @Suppress("EXPERIMENTAL_FEATURE_WARNING")
-internal inline class RawExpression(val value: String)
+@JvmInline
+internal value class RawExpression(val value: String)
 
 /**
  * Returns [CategoryName] by [name] string (case-insensitive).

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/dictionary/Dictionary.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/dictionary/Dictionary.kt
@@ -180,9 +180,9 @@ internal value class RawExpression(val value: String)
 /**
  * Returns [CategoryName] by [name] string (case-insensitive).
  */
-internal fun getCategoryName(name: String) = CategoryName.values().first { it.toLowerCase() == name.toLowerCase() }
+internal fun getCategoryName(name: String) = CategoryName.values().first { it.toLowerCase() == name.lowercase() }
 
-internal fun CategoryName.toLowerCase() = this.name.toLowerCase()
+internal fun CategoryName.toLowerCase() = this.name.lowercase()
 
 /**
  * Gets [Category] by its [name] from this [Dictionary].

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/Bank.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/Bank.kt
@@ -18,7 +18,7 @@ class Bank internal constructor(fakerService: FakerService) : AbstractFakeDataPr
     fun name() = resolve("name")
     fun swiftBic() = resolve("swift_bic")
     fun ibanDetails(countryCode: String): String {
-        val regex = resolve("iban_details", countryCode.toLowerCase())
+        val regex = resolve("iban_details", countryCode.lowercase())
             .drop(1)
             .dropLast(1)
             .split(", ")

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/Coffee.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/Coffee.kt
@@ -15,7 +15,7 @@ class Coffee internal constructor(fakerService: FakerService) : AbstractFakeData
     override val unique by UniqueProviderDelegate(localUniqueDataProvider)
 
     fun country() = resolve("country")
-    fun regions(country: String) = resolve("regions", country.toLowerCase())
+    fun regions(country: String) = resolve("regions", country.lowercase())
     fun variety() = resolve("variety")
     fun notes() = resolve("notes")
     fun blendName() = resolve("blend_name")

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/Dune.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/Dune.kt
@@ -17,8 +17,8 @@ class Dune internal constructor(fakerService: FakerService) : AbstractFakeDataPr
     fun characters() = resolve("characters")
     fun titles() = resolve("titles")
     fun planets() = resolve("planets")
-    fun quotes(character: String) = resolve("quotes", character.toLowerCase().replace("_", " "))
-    fun sayings(origin: String) = resolve("sayings", origin.toLowerCase().replace("_", " "))
+    fun quotes(character: String) = resolve("quotes", character.lowercase().replace("_", " "))
+    fun sayings(origin: String) = resolve("sayings", origin.lowercase().replace("_", " "))
 
     // TODO: 3/10/2019 would it be better to have enums for functions such as `quotes` to offer constrained number of values for `character`
 }

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/Internet.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/Internet.kt
@@ -22,7 +22,7 @@ class Internet internal constructor(fakerService: FakerService) : AbstractFakeDa
             fakerService.faker.name.name()
                 .replace(".", "")
                 .replace(" ", ".")
-                .toLowerCase()
+                .lowercase()
         } else name.replace(" ", "")
 
         return "$localName@${domain()}"
@@ -32,5 +32,5 @@ class Internet internal constructor(fakerService: FakerService) : AbstractFakeDa
     fun safeEmail(name: String = "") = "${email(name).substringBeforeLast(".")}.test"
 
     fun domainSuffix() = resolve("domain_suffix")
-    fun userAgent(browserType: String) = resolve("user_agent", browserType.toLowerCase())
+    fun userAgent(browserType: String) = resolve("user_agent", browserType.lowercase())
 }

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/StarWars.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/StarWars.kt
@@ -23,7 +23,7 @@ class StarWars internal constructor(fakerService: FakerService) : AbstractFakeDa
     fun species() = resolve("species")
     fun vehicles() = resolve("vehicles")
     fun wookieeWords() = resolve("wookiee_words")
-    fun quotes(character: String) = resolve("quotes", character.toLowerCase().replace("_", " "))
+    fun quotes(character: String) = resolve("quotes", character.lowercase().replace("_", " "))
     fun quote() = resolve("quotes", "")
     fun alternateCharacterSpellings(character: String) = resolve("alternate_character_spellings", character)
 }

--- a/core/src/test/kotlin/io/github/serpro69/kfaker/RandomServiceTest.kt
+++ b/core/src/test/kotlin/io/github/serpro69/kfaker/RandomServiceTest.kt
@@ -100,7 +100,7 @@ internal class RandomServiceTest : DescribeSpec({
             context("upperCase is true") {
                 it("random upper-case letter is generated") {
                     val letter = randomService.nextLetter(true).toString()
-                    source.toUpperCase() shouldContain letter
+                    source.uppercase() shouldContain letter
                 }
             }
 


### PR DESCRIPTION
I noticed some deprecation warnings in the build logs, so I decided to fix those. 

Maybe an idea to add to this PR: Replace `toLowerCase()` and `toUppercase()` methods on classes in this project to align them with the changes Kotlin made?