### PR TITLE
Add namedParameterGenerator for RandomProvider#randomClassInstance

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,10 +646,10 @@ class Test {
 
 #### Pre-Configuring type generation for constructor params
 
-Some, or all, of the constructor params can be instantiated with values following some pre-configured logic using `typeGenerator` function. Consider the following example:
+Some, or all, of the constructor params can be instantiated with values following some pre-configured logic using `typeGenerator` or `namedParameterGenerator` functions. Consider the following example:
 
 ```kotlin
-class Baz(val id: Int, val uuid: UUID)
+class Baz(val id: Int, val uuid: UUID, val relatedUuid: UUID)
 
 class Test {
     @Test
@@ -659,17 +659,18 @@ class Test {
         val baz: Baz = faker.randomProvider.randomClassInstance {
             typeGenerator<UUID> { UUID.fromString("00000000-0000-0000-0000-000000000000") }
             typeGenerator<Int> { 0 }
+            namedParameterGenerator("relatedUuid") { UUID.fromString("11111111-1111-1111-1111-111111111111") }
         }
-
     }
 }
 ```
 
 For each instance of `Baz` the following will be true:
 
-```
+```kotlin
 baz.id == 0
 baz.uuid == UUID.fromString("00000000-0000-0000-0000-000000000000")
+baz.relatedUuid == UUID.fromString("11111111-1111-1111-1111-111111111111")
 ```
 
 The example itself does not make that much sense, since we're using "static" values, but we could also do something like:

--- a/core/src/integration/kotlin/io/github/serpro69/kfaker/docs/Extras.kt
+++ b/core/src/integration/kotlin/io/github/serpro69/kfaker/docs/Extras.kt
@@ -24,16 +24,18 @@ class Extras : DescribeSpec({
         context("configurable constructor arg type generation") {
             it("should generate pre-configured constructor params") {
                 // START extras_random_instance_two
-                class Baz(val id: Int, val uuid: UUID)
+                class Baz(val id: Int, val uuid: UUID, val relatedUuid: UUID)
 
                 val baz: Baz = faker.randomProvider.randomClassInstance {
                     typeGenerator<UUID> { UUID.fromString("00000000-0000-0000-0000-000000000000") }
                     typeGenerator<Int> { 0 }
+                    namedParameterGenerator("relatedUuid") { UUID.fromString("11111111-1111-1111-1111-111111111111") }
                 }
+                // END extras_random_instance_two
 
                 assertEquals(baz.id, 0)
                 assertEquals(baz.uuid, UUID.fromString("00000000-0000-0000-0000-000000000000"))
-                // END extras_random_instance_two
+                assertEquals(baz.relatedUuid, UUID.fromString("11111111-1111-1111-1111-111111111111"))
             }
         }
 

--- a/core/src/test/kotlin/io/github/serpro69/kfaker/provider/RandomProviderTest.kt
+++ b/core/src/test/kotlin/io/github/serpro69/kfaker/provider/RandomProviderTest.kt
@@ -186,6 +186,38 @@ class RandomProviderTest : DescribeSpec({
         }
     }
 
+    describe("a TestClass with non-empty constructor for custom parameter generators") {
+        class TestClass(
+            val id: UUID,
+            val id2: UUID,
+            val nullableId: UUID?,
+            val nullableId2: UUID?
+        )
+
+        val typeGeneratedId = UUID.fromString("00000000-0000-0000-0000-000000000000")
+        val namedParameterGeneratedId = UUID.randomUUID()
+        val nullableNamedParameterGeneratedId = UUID.randomUUID()
+
+        context("creating a random instance of the class with custom parameter and type generators") {
+            val testClass: TestClass = randomProvider.randomClassInstance {
+                namedParameterGenerator("id") { namedParameterGeneratedId }
+                namedParameterGenerator("nullableId") { nullableNamedParameterGeneratedId }
+                namedParameterGenerator("nullableId2") { null }
+                typeGenerator<UUID> { typeGeneratedId }
+            }
+
+            it("should use predefined UUIDs with parameter generators taking precedence over type generators") {
+                assertSoftly {
+                    testClass shouldBe instanceOf(TestClass::class)
+                    testClass.id shouldBe namedParameterGeneratedId
+                    testClass.id2 shouldBe typeGeneratedId
+                    testClass.nullableId shouldBe nullableNamedParameterGeneratedId
+                    testClass.nullableId2 shouldBe null
+                }
+            }
+        }
+    }
+
     describe("a TestClass with non-empty constructor for nullable custom type generators") {
         class Foo(val int: Int?)
         class TestClass(

--- a/docs/src/orchid/resources/wiki/extras.md
+++ b/docs/src/orchid/resources/wiki/extras.md
@@ -44,7 +44,8 @@ Random instance generation is available through `Faker().randomProvider`:
 
 ### Pre-Configuring type generation for constructor arguments
 
-Some, or all, of the constructor params can be instantiated with values following some pre-configured logic using `typeGenerator` function. Consider the following example:
+Some, or all, of the constructor params can be instantiated with values following some pre-configured logic using `typeGenerator` or `namedParameterGenerator` functions. Consider the following example:
+
 
 {% tabs %}
 
@@ -61,9 +62,10 @@ Some, or all, of the constructor params can be instantiated with values followin
 <br>
 So for each instance of `Baz` the following will be true:
 
-```
+```kotlin
 baz.id == 0
 baz.uuid == UUID.fromString("00000000-0000-0000-0000-000000000000")
+baz.relatedUuid == UUID.fromString("11111111-1111-1111-1111-111111111111")
 ```
 
 This example itself does not make that much sense, since we're using "static" values, but we could also do something like:


### PR DESCRIPTION
Faker provides the ability to create a random object instance for a specific type, and to override the generation of the object's fields by type as described in this example from the documentation:

```kotlin
class Baz(val id: Int, val uuid: UUID)

val baz: Baz = faker.randomProvider.randomClassInstance {
    typeGenerator<UUID> { UUID.fromString("00000000-0000-0000-0000-000000000000") }
}
```

This is great, but sometimes the objects we generate are required to be related in a way that makes overriding by type not granular enough. For example, if an object of one class must hold an ID of an object of another class, generation by type would not allow us to form a valid relationship.

```kotlin
class Foo(val id: Int, val bazId: Int)

val foo: Foo = faker.randomProvider.randomClassInstance {
    typeGenerator<Int> { 42 }
}

```

Here `bazId` should be set equal to `baz.id`, but instead both `id` and `bazId` will be `42` and (unless I'm mistaken) a mechanism doesn't exist to assign a specific yet different value to fields of the same type. 

One way to solve this problem would be to provide a way to override field generation not by type but by constructor parameter name, as in this example:

```kotlin
val foo: Foo = faker.randomProvider.randomClassInstance {
    namedParameterGenerator("bazId") { baz.id }
}
```

This is what is implemented in this PR. Looking forward to hearing your thoughts on whether this is a worthwhile addition, or if there is a better way to achieve my aims.

