### PR TITLE
Fix docs api reference linking

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,3 +1,4 @@
-# faker core
+---
+---
 
-<strong>This page is still under development</strong>
+## [{{page.title}}]({{page.link}})

--- a/docs/src/orchid/resources/config.yml
+++ b/docs/src/orchid/resources/config.yml
@@ -64,7 +64,10 @@ theme:
       menu:
         - type: 'sourcedocModules'
           moduleType: 'kotlindoc'
-          moduleGroup: 'core'
+          moduleGroup: 'full'
+        - type: 'sourcedocModules'
+          moduleType: 'kotlindoc'
+          moduleGroup: 'data-provider'
     - type: 'submenu'
       title: 'Information'
       icon: 'info-circle'
@@ -121,7 +124,7 @@ kotlindoc:
   #   generate module homepages. Dokka takes a few seconds to start up, which
   #   makes rapid iteration a bit painful, so it may be helpful to disable it
   #   when making changes to the site.
-  homePageOnly: true
+#  homePageOnly: true
   homePagePermalink: 'modules/:module'
   sourcePagePermalink: ':moduleType/:module/:sourceDocPath'
   sourcePages:
@@ -130,12 +133,17 @@ kotlindoc:
         itemTitleType: 'signature' # optional, one of [NAME, ID, SIGNATURE]
         includeItems: true # optional
   modules:
-    - name: 'Core API'
-      slug: 'core'
+    - name: 'Full Core API'
+      slug: 'full'
       sourceDirs:
         - './../../../../core/src/main/kotlin/'
         - './../../../../core/src/main/java/'
-      moduleGroup: 'core'
+      moduleGroup: 'full'
+    - name: 'Data Provider API'
+      slug: 'data-provider'
+      sourceDirs:
+        - './../../../../core/src/main/kotlin/io/github/serpro69/kfaker/provider'
+      moduleGroup: 'data-provider'
 
 snippets:
   sections:


### PR DESCRIPTION
It seems that orchid is failing to link kotlindoc pages for multi-module configuration
( https://orchid.run/plugins/orchidkotlindoc#multi-module-usage )
when only one module is specified in the `kotlindoc.modules` config.

As a workaround, I've added two modules for `kotlindoc` configuration,
one for "full core api" reference, and another only covering
`provider` package classes.