### PR TITLE
Fix postcode for en-GB locale

### DIFF
--- a/core/src/integration/kotlin/io/github/serpro69/kfaker/provider/AddressIT.kt
+++ b/core/src/integration/kotlin/io/github/serpro69/kfaker/provider/AddressIT.kt
@@ -65,5 +65,11 @@ class AddressIT : DescribeSpec({
                 address("fr").fullAddress() shouldContain Regex("""\d{5}""")
             }
         }
+
+        context("en-GB locale") {
+            it("should generate a valid postcode") {
+                address("en-GB").postcode() shouldMatch Regex("""[A-Z]{1,2}\d{1,2}[A-Z]* [\d][A-Z][A-Z]""")
+            }
+        }
     }
 })

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/Address.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/Address.kt
@@ -33,7 +33,7 @@ class Address internal constructor(fakerService: FakerService) : YamlFakeDataPro
     fun secondaryAddress() = with(fakerService) { resolve("secondary_address").numerify() }
     fun postcode() = with(fakerService) {
         when (faker.config.locale) {
-            "nl" -> resolve("postcode").generexify().replace("/", "")
+            "nl", "en-GB" -> resolve("postcode").generexify().replace("/", "")
             else -> resolve("postcode").numerify()
         }
     }


### PR DESCRIPTION
This is a fix for https://github.com/serpro69/kotlin-faker/issues/187 which is related to address postcode generation for `en-GB` locale.
