### PR TITLE
Allow randomClassInstance to directly use predefined generators

### DIFF
--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/ParameterInfo.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/ParameterInfo.kt
@@ -3,9 +3,9 @@ package io.github.serpro69.kfaker.provider.misc
 import kotlin.reflect.KParameter
 
 /**
- * Provides additional informations about Class parameter to custom defined generators.
- * The reason why is not used KParameter is that you will want to provide
- * additional informations about parameter that is not available in KParameter class.
+ * Provides additional information about Class parameter to custom defined generators.
+ * The reason why KParameter is not used is that you will want to provide
+ * additional information about parameter that is not available in KParameter class.
  */
 data class ParameterInfo(
     val index: Int,
@@ -17,7 +17,7 @@ data class ParameterInfo(
 /**
  * Extension function that maps KParameter to ParameterInfo dataclass.
  */
-fun KParameter.toParameterInfo() = ParameterInfo(
+internal fun KParameter.toParameterInfo() = ParameterInfo(
     index = index,
     name = name.toString(),
     isOptional = isOptional,

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProvider.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProvider.kt
@@ -122,7 +122,7 @@ class RandomClassProvider {
         val predefinedInstance: T? by lazy {
             predefinedTypeOrNull(
                 config,
-                // it's not a constructor parameter, so set some hardcoded values instead for ParameterInfo
+                // it's not a constructor parameter, so set some hardcoded values for ParameterInfo
                 ParameterInfo(index = -1, name = jvmName, isOptional = false, isVararg = false)
             ) as T?
         }

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProvider.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProvider.kt
@@ -2,7 +2,12 @@ package io.github.serpro69.kfaker.provider.misc
 
 import io.github.serpro69.kfaker.FakerConfig
 import io.github.serpro69.kfaker.RandomService
-import java.util.*
+import io.github.serpro69.kfaker.provider.misc.ConstructorFilterStrategy.MAX_NUM_OF_ARGS
+import io.github.serpro69.kfaker.provider.misc.ConstructorFilterStrategy.MIN_NUM_OF_ARGS
+import io.github.serpro69.kfaker.provider.misc.ConstructorFilterStrategy.NO_ARGS
+import io.github.serpro69.kfaker.provider.misc.FallbackStrategy.FAIL_IF_NOT_FOUND
+import io.github.serpro69.kfaker.provider.misc.FallbackStrategy.USE_MAX_NUM_OF_ARGS
+import io.github.serpro69.kfaker.provider.misc.FallbackStrategy.USE_MIN_NUM_OF_ARGS
 import kotlin.Boolean
 import kotlin.Char
 import kotlin.Double
@@ -14,6 +19,7 @@ import kotlin.String
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.KVisibility
+import kotlin.reflect.jvm.jvmName
 
 /**
  * Provider functionality for generating random class instances.
@@ -102,62 +108,67 @@ class RandomClassProvider {
     @JvmSynthetic
     @PublishedApi
     internal fun <T : Any> KClass<T>.randomClassInstance(config: RandomProviderConfig): T {
-        val defaultInstance: T? = if (
-            config.constructorParamSize == -1
-            && config.constructorFilterStrategy == ConstructorFilterStrategy.NO_ARGS
-        ) {
-            randomPrimitiveOrNull() as T? ?: try {
-                constructors.firstOrNull { it.parameters.isEmpty() && it.visibility == KVisibility.PUBLIC }?.call()
-            } catch (e: Exception) {
-                throw InstantiationException("Failed to instantiate $this")
-                    .initCause(e)
-            }
-        } else null
+        val defaultInstance: T? by lazy {
+            if (config.constructorParamSize == -1 && config.constructorFilterStrategy == NO_ARGS) {
+                randomPrimitiveOrNull() as T? ?: try {
+                    constructors.firstOrNull { it.parameters.isEmpty() && it.visibility == KVisibility.PUBLIC }?.call()
+                } catch (e: Exception) {
+                    throw InstantiationException("Failed to instantiate $this")
+                        .initCause(e)
+                }
+            } else null
+        }
 
-        return defaultInstance ?: objectInstance ?: run {
-            val constructors = constructors
-                .filter { it.visibility == KVisibility.PUBLIC }
+        val predefinedInstance: T? by lazy {
+            predefinedTypeOrNull(
+                config,
+                // it's not a constructor parameter, so set some hardcoded values instead for ParameterInfo
+                ParameterInfo(index = -1, name = jvmName, isOptional = false, isVararg = false)
+            ) as T?
+        }
+
+        return objectInstance ?: defaultInstance ?: run {
+            val constructors = constructors.filter { it.visibility == KVisibility.PUBLIC }
 
             val constructor = constructors.firstOrNull {
                 it.parameters.size == config.constructorParamSize
             } ?: when (config.constructorFilterStrategy) {
-                ConstructorFilterStrategy.MIN_NUM_OF_ARGS -> constructors.minByOrNull { it.parameters.size }
-                ConstructorFilterStrategy.MAX_NUM_OF_ARGS -> constructors.maxByOrNull { it.parameters.size }
+                MIN_NUM_OF_ARGS -> constructors.minByOrNull { it.parameters.size }
+                MAX_NUM_OF_ARGS -> constructors.maxByOrNull { it.parameters.size }
                 else -> {
                     when (config.fallbackStrategy) {
-                        FallbackStrategy.FAIL_IF_NOT_FOUND -> {
+                        FAIL_IF_NOT_FOUND -> {
                             throw NoSuchElementException("Constructor with 'parameters.size == ${config.constructorParamSize}' not found for $this")
                         }
-                        FallbackStrategy.USE_MIN_NUM_OF_ARGS -> constructors.minByOrNull { it.parameters.size }
-                        FallbackStrategy.USE_MAX_NUM_OF_ARGS -> constructors.maxByOrNull { it.parameters.size }
+                        USE_MIN_NUM_OF_ARGS -> constructors.minByOrNull { it.parameters.size }
+                        USE_MAX_NUM_OF_ARGS -> constructors.maxByOrNull { it.parameters.size }
                     }
                 }
-            } ?: throw NoSuchElementException("No suitable constructor found for $this")
+            }
+            ?: predefinedInstance?.let { return@run it }
+            ?: throw NoSuchElementException("No suitable constructor or predefined instance found for $this")
 
-            val params = constructor.parameters
-                .map {
-
-                    val pInfo = it.toParameterInfo()
-
-                    val klass = it.type.classifier as KClass<*>
-                    when {
-                        config.namedParameterGenerators.containsKey(it.name) -> {
-                            config.namedParameterGenerators[it.name]?.invoke(pInfo)
-                        }
-                        it.type.isMarkedNullable && config.nullableGenerators.containsKey(klass) -> {
-                            config.nullableGenerators[klass]?.invoke(pInfo)
-                        }
-                        else -> {
-                            klass.predefinedTypeOrNull(config, pInfo)
-                                ?: klass.randomPrimitiveOrNull()
-                                ?: klass.objectInstance
-                                ?: klass.randomEnumOrNull()
-                                ?: klass.randomSealedClassOrNull(config)
-                                ?: klass.randomCollectionOrNull(it.type, config)
-                                ?: klass.randomClassInstance(config)
-                        }
+            val params = constructor.parameters.map {
+                val pInfo = it.toParameterInfo()
+                val klass = it.type.classifier as KClass<*>
+                when {
+                    config.namedParameterGenerators.containsKey(it.name) -> {
+                        config.namedParameterGenerators[it.name]?.invoke(pInfo)
+                    }
+                    it.type.isMarkedNullable && config.nullableGenerators.containsKey(klass) -> {
+                        config.nullableGenerators[klass]?.invoke(pInfo)
+                    }
+                    else -> {
+                        klass.objectInstance
+                            ?: klass.predefinedTypeOrNull(config, pInfo)
+                            ?: klass.randomPrimitiveOrNull()
+                            ?: klass.randomEnumOrNull()
+                            ?: klass.randomSealedClassOrNull(config)
+                            ?: klass.randomCollectionOrNull(it.type, config)
+                            ?: klass.randomClassInstance(config)
                     }
                 }
+            }
 
             try {
                 constructor.call(*params.toTypedArray())
@@ -242,8 +253,8 @@ class RandomClassProvider {
 class RandomProviderConfig @PublishedApi internal constructor() {
     var collectionsSize: Int = 1
     var constructorParamSize: Int = -1
-    var constructorFilterStrategy: ConstructorFilterStrategy = ConstructorFilterStrategy.NO_ARGS
-    var fallbackStrategy: FallbackStrategy = FallbackStrategy.USE_MIN_NUM_OF_ARGS
+    var constructorFilterStrategy: ConstructorFilterStrategy = NO_ARGS
+    var fallbackStrategy: FallbackStrategy = USE_MIN_NUM_OF_ARGS
 
     @PublishedApi
     internal val namedParameterGenerators = mutableMapOf<String, (pInfo: ParameterInfo) -> Any?>()
@@ -277,14 +288,13 @@ class RandomProviderConfig @PublishedApi internal constructor() {
     inline fun <reified K : Any?> nullableTypeGenerator(noinline generator: (pInfo: ParameterInfo) -> K?) {
         nullableGenerators[K::class] = generator
     }
-
 }
 
 private fun RandomProviderConfig.reset() {
     collectionsSize = 1
     constructorParamSize = -1
-    constructorFilterStrategy = ConstructorFilterStrategy.NO_ARGS
-    fallbackStrategy = FallbackStrategy.USE_MIN_NUM_OF_ARGS
+    constructorFilterStrategy = NO_ARGS
+    fallbackStrategy = USE_MIN_NUM_OF_ARGS
     namedParameterGenerators.clear()
     predefinedGenerators.clear()
     nullableGenerators.clear()

--- a/core/src/test/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProviderTest.kt
+++ b/core/src/test/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProviderTest.kt
@@ -12,7 +12,6 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldHaveLength
 import io.kotest.matchers.types.instanceOf
 import io.kotest.matchers.types.shouldNotBeSameInstanceAs
-import java.time.Instant
 import java.util.*
 import kotlin.reflect.full.declaredMemberProperties
 
@@ -136,8 +135,8 @@ class RandomClassProviderTest : DescribeSpec({
         }
     }
 
-    describe("a TestClass with no public constructors") {
-        context("creating a random instance of the class") {
+    describe("no public constructors") {
+        context("creating a random instance of a class") {
             it("should return a predefined instance via typeGenerator") {
                 val testClassMin = randomProvider.randomClassInstance<TestClassNoPublic> {
                     typeGenerator<TestClassNoPublic> { TestClassNoPublic.MIN }
@@ -153,6 +152,21 @@ class RandomClassProviderTest : DescribeSpec({
                     randomProvider.randomClassInstance<TestClassNoPublic>()
                 }
                 exception.message shouldBe "No suitable constructor or predefined instance found for ${TestClassNoPublic::class}"
+            }
+        }
+        context("creating a random instance of an interface") {
+            it("should return a predefined interface instance via typeGenerator") {
+                val testInterface = randomProvider.randomClassInstance<TestInterface> {
+                    typeGenerator<TestInterface> {
+                        object : TestInterface {
+                            override val id: Int = 42
+                            override val name: String = "Deep Thought"
+                        }
+                    }
+                }
+
+                testInterface.id shouldBe 42
+                testInterface.name shouldBe "Deep Thought"
             }
         }
     }
@@ -724,4 +738,9 @@ class TestClassNoPublic private constructor(val id: Int) {
         val MIN = TestClassNoPublic(Int.MIN_VALUE)
         val MAX = TestClassNoPublic(Int.MAX_VALUE)
     }
+}
+
+interface TestInterface {
+    val id: Int
+    val name: String
 }

--- a/docs/src/orchid/resources/wiki/extras.md
+++ b/docs/src/orchid/resources/wiki/extras.md
@@ -9,7 +9,7 @@
 
 * [Random instance of any class](#random-instance-of-any-class)
   * [Random Class Instance Configuration](#random-class-instance-configuration)
-  * [Pre-configuring type generation for constructor arguments](#pre-configuring-type-generation-for-constructor-arguments)
+  * [Pre-configuring type generation](#pre-configuring-type-generation)
   * [Deterministic constructor selection](#deterministic-constructor-selection)
   * [Configuring the size of generated Collections](#configuring-the-size-of-generated-collections)
   * [Making a Copy or a New instance of RandomClassProvider](#making-a-new-instance-of-random-class-provider)
@@ -122,10 +122,11 @@ This configuration takes the most precedence and does not take into account conf
 
 <br>
 
-### Pre-Configuring type generation for constructor arguments
+### Pre-Configuring type generation
+
+#### Predefined types for constructor parameters
 
 Some, or all, of the constructor params can be instantiated with values following some pre-configured logic using `typeGenerator` or `namedParameterGenerator` functions. Consider the following example:
-
 
 {% tabs %}
 
@@ -183,6 +184,34 @@ val person: Person = faker.randomProvider.randomClassInstance {
 {% endkotlin %}
 
 {% endtabs %}
+
+<br>
+
+#### Pre-defined instance for classes with no public constructors
+
+By default, `randomClassInstance` can't generate classes with no public constructors, but this can be worked around by using `typeGenerator`:
+
+{% tabs %}
+
+{% kotlin "Kotlin" %}
+{% filter compileAs('md') %}
+```kotlin
+faker.randomProvider.randomClassInstance<Instant> {
+    typeGenerator<Instant> { Instant.now() }
+}
+```
+{% endfilter %}
+{% endkotlin %}
+
+{% endtabs %}
+
+A random class instance will be generated using the following precedence rules:
+
+- object instance
+- "default instance" of a class
+  - uses the public constructor with the least number of arguments, unless otherwise configured (see [Random Class Instance Configuration]({{ link(collectionType='wiki', collectionId='', itemId='Extras') }}#random-class-instance-configuration))
+- "predefined instance" of a class if no public constructors are found
+- failing all of the above, `NoSuchElementException` will be thrown
 
 {% btc %}{% endbtc %}
 

--- a/docs/src/orchid/resources/wiki/extras.md
+++ b/docs/src/orchid/resources/wiki/extras.md
@@ -205,6 +205,35 @@ faker.randomProvider.randomClassInstance<Instant> {
 
 {% endtabs %}
 
+You could also use the same approach to create interfaces, for example:
+
+{% tabs %}
+
+{% kotlin "Kotlin" %}
+{% filter compileAs('md') %}
+```kotlin
+interface TestInterface {
+  val id: Int
+  val name: String
+}
+
+val testInterface = randomProvider.randomClassInstance<TestInterface> {
+  typeGenerator<TestInterface> {
+    object : TestInterface {
+      override val id: Int = 42
+      override val name: String = "Deep Thought"
+    }
+  }
+}
+
+testInterface.id shouldBe 42
+testInterface.name shouldBe "Deep Thought"
+```
+{% endfilter %}
+{% endkotlin %}
+
+{% endtabs %}
+
 A random class instance will be generated using the following precedence rules:
 
 - object instance


### PR DESCRIPTION
Closes #201 

Still not sure what the precedence should be, but I think it makes more sense to first try a default instance with public constructor. But I could probably as easy argue for the other way around , so I'm really just winging it here :D 