### PR TITLE
Fix Person.birthDate range error during leap year

### DIFF
--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/Person.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/Person.kt
@@ -34,7 +34,8 @@ class Person internal constructor(private val random: Random) {
     fun birthDate(age: Long, at: LocalDate = LocalDate.now()): LocalDate {
         val startDate = at.minusYears(age + 1)
         val endDate = startDate.plusYears(1).minusDays(1)
-        val lower = LocalDate.ofYearDay(startDate.year, (startDate.dayOfYear..365).random(random.asKotlinRandom()))
+        val startMaxDays = if (startDate.isLeapYear) 366 else 365
+        val lower = LocalDate.ofYearDay(startDate.year, (startDate.dayOfYear..startMaxDays).random(random.asKotlinRandom()))
         val upper = LocalDate.ofYearDay(endDate.year, (1..endDate.dayOfYear).random(random.asKotlinRandom()))
         val dates = if (lower.month == at.month && lower.dayOfMonth == at.dayOfMonth) {
             lower.plusDays(1) to upper

--- a/docs/src/orchid/resources/data.yml
+++ b/docs/src/orchid/resources/data.yml
@@ -25,6 +25,8 @@ contributors:
   link: https://github.com/urosjarc
 - name: Rafał Spryszyński
   link: https://github.com/Rafal-Spryszynski-Allegro
+- name: João Moreira
+  link: https://github.com/JoaoSouMoreira
 
 homepageSections:
   - title: '…a plethora of real-looking data in various domains:'


### PR DESCRIPTION
Hello, first of all thank you for creating this incredibly useful library.

The company I work at uses this library extensive in its automated testing, and during an incident on Dec 31st 2023 we started seeing randomly failing tests with the following error:
```bash
java.util.NoSuchElementException: Cannot get random in empty range: 366..365
	at kotlin.ranges.RangesKt___RangesKt.random(_Ranges.kt:193)
	at io.github.serpro69.kfaker.provider.Person.birthDate(Person.kt:38)
	at io.github.serpro69.kfaker.provider.Person.birthDate$default(Person.kt:34)
	at io.github.serpro69.kfaker.provider.PersonTest$1$1$1$2.invokeSuspend(PersonTest.kt:25)
```

After looking through the `birthDate` method's code and seeing the hard coded 365 I immediately assumed it would have been related to leap years, though I am still confused as to why Java recognizes `LocalDate.now().isLeapYear` as true on Dec 31st 2023. I think this change will fix the issue regardless.

**Reproduction steps**:
- Change your device's date to December 31st 2023 (time does not matter)
- Run all tests in PersonTest.kt
- See test `birthDate(age) fun` failing with the error outlined above.