### PR TITLE
Replace generex with rgxgen

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,7 +18,8 @@
 [discrete]
 === Fixed
 
-* ...
+* https://github.com/serpro69/kotlin-faker/issues/207[#207] (:core) Regexify generates invalid value 
+* https://github.com/serpro69/kotlin-faker/issues/208[#208] (:core) Regexify fails with StackOverflowError
 
 [discrete]
 === Other

--- a/buildSrc/src/main/kotlin/faker-lib-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/faker-lib-conventions.gradle.kts
@@ -81,9 +81,9 @@ dependencies {
         version { strictly("1.3.4") /* last stable for java 8 */ }
     }
     testRuntimeOnly("org.codehaus.groovy:groovy:3.0.19")
-    // we're shadowing these so they need to be available for test runtime
+    // we're shadowing these, so they need to be available for test runtime
     testRuntimeOnly(libs.icu4j)
-    testRuntimeOnly(libs.generex)
+    testRuntimeOnly(libs.rgxgen)
 }
 
 val integrationTest by tasks.creating(Test::class) {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -84,12 +84,12 @@ public final class io/github/serpro69/kfaker/FakerKt {
 }
 
 public final class io/github/serpro69/kfaker/FakerService {
-	public final fun getGenerexify (Ljava/lang/String;)Lkotlin/jvm/functions/Function0;
 	public final fun getLetterify (Ljava/lang/String;)Lkotlin/jvm/functions/Function1;
 	public final fun getNumerify (Ljava/lang/String;)Lkotlin/jvm/functions/Function0;
 	public final fun getRawValue-DOu9s8A (Lio/github/serpro69/kfaker/dictionary/YamlCategory;Ljava/lang/String;)Ljava/lang/String;
 	public final fun getRawValue-EpprjwY (Lio/github/serpro69/kfaker/dictionary/YamlCategory;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public final fun getRawValue-f6CUTBQ (Lio/github/serpro69/kfaker/dictionary/YamlCategory;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun getRegexify (Ljava/lang/String;)Lkotlin/jvm/functions/Function0;
 	public final fun letterify (Ljava/lang/String;)Ljava/lang/String;
 	public final fun load (Lio/github/serpro69/kfaker/dictionary/YamlCategory;Lio/github/serpro69/kfaker/dictionary/Category;)Ljava/util/EnumMap;
 	public static synthetic fun load$default (Lio/github/serpro69/kfaker/FakerService;Lio/github/serpro69/kfaker/dictionary/YamlCategory;Lio/github/serpro69/kfaker/dictionary/Category;ILjava/lang/Object;)Ljava/util/EnumMap;

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 dependencies {
     implementation(libs.bundles.jackson)
     shadow(libs.icu4j)
-    shadow(libs.generex)
+    shadow(libs.rgxgen)
 }
 
 apply<Yaml2JsonPlugin>() // this shouldn't really be needed since the plugin is supposed to be applied in the plugins{} block

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/FakerService.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/FakerService.kt
@@ -1,6 +1,6 @@
 package io.github.serpro69.kfaker
 
-import com.mifmif.common.regex.Generex
+import com.github.curiousoddman.rgxgen.RgxGen
 import io.github.serpro69.kfaker.dictionary.Category
 import io.github.serpro69.kfaker.dictionary.Dictionary
 import io.github.serpro69.kfaker.dictionary.RawExpression
@@ -543,8 +543,8 @@ class FakerService {
      */
     fun String.letterify() = letterify(true)
 
-    val String.generexify: () -> String
-        get() = { Generex(this, faker.config.random).random() }
+    val String.regexify: () -> String
+        get() = { RgxGen.parse(this).generate(faker.config.random) }
 
     /**
      * Calls the property of this [FakeDataProvider] receiver and returns the result as [String].

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/FakerService.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/FakerService.kt
@@ -543,6 +543,9 @@ class FakerService {
      */
     fun String.letterify() = letterify(true)
 
+    /**
+     * Returns a random string generated from this [String] receiver pattern.
+     */
     val String.regexify: () -> String
         get() = { RgxGen.parse(this).generate(faker.config.random) }
 

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/Address.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/Address.kt
@@ -36,7 +36,7 @@ class Address internal constructor(fakerService: FakerService) : YamlFakeDataPro
         val pattern = resolve("postcode")
         when {
             pattern.contains('#') -> pattern.numerify()
-            else -> pattern.generexify().replace("/", "")
+            else -> pattern.regexify().replace("/", "")
         }
     }
 

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/CryptographyProvider.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/CryptographyProvider.kt
@@ -47,6 +47,6 @@ class CryptographyProvider internal constructor(
     fun sha512(): String = sha(128)
 
     private fun sha(len: Int): String = with(fakerService) {
-        resolveUniqueValue("generexify") { """[a-f0-9]{$len}""".generexify() }
+        resolveUniqueValue("regexify") { """[a-f0-9]{$len}""".regexify() }
     }
 }

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/StringProvider.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/StringProvider.kt
@@ -45,6 +45,9 @@ class StringProvider internal constructor(
     /**
      * Returns a string of generated values based on the regex expressions in the [template] input,
      * for example `regexify("""\d{3}""")` will return a string consisting of 3 random digits.
+     *
+     * _Refer to [RgxGen's Supported Syntax](https://github.com/curious-odd-man/RgxGen?tab=readme-ov-file#supported-syntax)
+     * documentation for details on what regex syntax is supported._
      */
     fun regexify(template: String) = with(fakerService) {
         resolveUniqueValue("regexify", template.regexify)
@@ -53,6 +56,9 @@ class StringProvider internal constructor(
     /**
      * Returns a string of generated values based on the [regex],
      * for example `regexify(Regex("""\d{3}"""))` will return a string consisting of 3 random digits.
+     *
+     * _Refer to [RgxGen's Supported Syntax](https://github.com/curious-odd-man/RgxGen?tab=readme-ov-file#supported-syntax)
+     * documentation for details on what regex syntax is supported._
      */
     fun regexify(regex: Regex) = with(fakerService) {
         resolveUniqueValue("regexify", regex.toString().regexify)

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/StringProvider.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/StringProvider.kt
@@ -47,7 +47,7 @@ class StringProvider internal constructor(
      * for example `regexify("""\d{3}""")` will return a string consisting of 3 random digits.
      */
     fun regexify(template: String) = with(fakerService) {
-        resolveUniqueValue("regexify", template.generexify)
+        resolveUniqueValue("regexify", template.regexify)
     }
 
     /**
@@ -55,6 +55,6 @@ class StringProvider internal constructor(
      * for example `regexify(Regex("""\d{3}"""))` will return a string consisting of 3 random digits.
      */
     fun regexify(regex: Regex) = with(fakerService) {
-        resolveUniqueValue("regexify", regex.toString().generexify)
+        resolveUniqueValue("regexify", regex.toString().regexify)
     }
 }

--- a/core/src/test/kotlin/io/github/serpro69/kfaker/FakerServiceTest.kt
+++ b/core/src/test/kotlin/io/github/serpro69/kfaker/FakerServiceTest.kt
@@ -1,14 +1,13 @@
 package io.github.serpro69.kfaker
 
 import io.github.serpro69.kfaker.dictionary.Category
-import io.github.serpro69.kfaker.dictionary.YamlCategoryData
 import io.github.serpro69.kfaker.dictionary.Dictionary
 import io.github.serpro69.kfaker.dictionary.YamlCategory
+import io.github.serpro69.kfaker.dictionary.YamlCategoryData
 import io.github.serpro69.kfaker.exception.DictionaryKeyNotFoundException
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.collections.shouldBeIn
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactly
@@ -21,8 +20,10 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldHaveSameLengthAs
+import io.kotest.matchers.string.shouldMatch
 import io.kotest.matchers.string.shouldNotContain
-import java.util.*
+import java.util.Locale
+import java.util.Random
 
 val random = Random()
 
@@ -570,6 +571,25 @@ internal class FakerServiceTest : DescribeSpec({
 //                }
 //            }
 //        }
+    }
+
+    describe("regexify a string") {
+        val s = FakerService(Faker())
+        it("should match the provided pattern - gh #207") {
+            val rr = listOf(
+                // NB! lookahead and lookbehind has limited support in RgxGen
+                // (https://github.com/curious-odd-man/RgxGen/issues/63)
+                // """^[a-zA-Z\d](?:[a-zA-Z\d]|-(?!-)){0,38}${'$'}""",
+                """^AKIA\S{16}${'$'}""",
+                """^\S{40}${'$'}""",
+                """^i-0[\da-f]{16}${'$'}"""
+            )
+            rr.forEach { with(s) { it.regexify() shouldMatch Regex(it) } }
+        }
+        it("should not throw SO - gh #209") {
+            val r = """^arn:.+:.+:.*:([0-9]{12}):(.+)${'$'}"""
+            with(s) { r.regexify() shouldMatch Regex(r) }
+        }
     }
 })
 

--- a/faker/commerce/src/integration/kotlin/io/github/serpro69/kfaker/commerce/provider/FinanceIT.kt
+++ b/faker/commerce/src/integration/kotlin/io/github/serpro69/kfaker/commerce/provider/FinanceIT.kt
@@ -9,7 +9,7 @@ class FinanceIT : DescribeSpec({
     describe("Finance Provider") {
         val finance = faker { }.finance
 
-        context("generexifying strings") {
+        context("regexifying strings") {
             repeat(10) {
                 it("creditCard() does NOT contain regex expressions run#$it") {
                     assertSoftly {

--- a/faker/commerce/src/main/kotlin/io/github/serpro69/kfaker/commerce/provider/Bank.kt
+++ b/faker/commerce/src/main/kotlin/io/github/serpro69/kfaker/commerce/provider/Bank.kt
@@ -30,6 +30,6 @@ class Bank internal constructor(fakerService: FakerService) : YamlFakeDataProvid
             .last()
             .split("=")
             .last()
-            .generexify()
+            .regexify()
     }
 }

--- a/faker/commerce/src/main/kotlin/io/github/serpro69/kfaker/commerce/provider/Finance.kt
+++ b/faker/commerce/src/main/kotlin/io/github/serpro69/kfaker/commerce/provider/Finance.kt
@@ -23,7 +23,7 @@ class Finance internal constructor(
         fakerService.load(yamlCategory)
     }
 
-    fun creditCard(type: String): String = with(fakerService) { resolve("credit_card", type).numerify().generexify() }
+    fun creditCard(type: String): String = with(fakerService) { resolve("credit_card", type).numerify().regexify() }
     fun condominiumFiscalCode(): String = with(fakerService) { resolve("condominium_fiscal_code", "IT").numerify() }
     fun vatNumber(countryCode: String): String = with(fakerService) { resolve("vat_number", countryCode).numerify() }
     fun ticker(stockExchange: StockExchange = randomService.nextEnum()): String =

--- a/faker/tech/src/integration/kotlin/io/github/serpro69/kfaker/tech/provider/VehicleIT.kt
+++ b/faker/tech/src/integration/kotlin/io/github/serpro69/kfaker/tech/provider/VehicleIT.kt
@@ -9,7 +9,7 @@ class VehicleIT : DescribeSpec({
     describe("Vehicle Provider") {
         val vehicle = faker { }.vehicle
 
-        context("generexifying strings") {
+        context("regexifying strings") {
             repeat(10) {
                 it("licensePlateByState() does NOT contain regex expressions run#$it") {
                     assertSoftly {

--- a/faker/tech/src/main/kotlin/io/github/serpro69/kfaker/tech/provider/Vehicle.kt
+++ b/faker/tech/src/main/kotlin/io/github/serpro69/kfaker/tech/provider/Vehicle.kt
@@ -35,7 +35,7 @@ class Vehicle internal constructor(fakerService: FakerService) : YamlFakeDataPro
     fun engineSizes() = resolve("engine_sizes")
     fun licensePlate() = with(fakerService) { resolve("license_plate").numerify().letterify() }
     fun licencePlateByState(stateCode: String) = with(fakerService) {
-        resolve("license_plate_by_state", stateCode).numerify().letterify().generexify()
+        resolve("license_plate_by_state", stateCode).numerify().letterify().regexify()
     }
 
     fun cylinderEngine() = resolve("cylinder_engine")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 classgraph = "4.8.165"
 commons-io = "2.15.1"
-generex = "1.0.2"
 icu4j = "73.2"
 jackson = "2.15.3"
 kotlin = "1.9.21"
 kotlinpoet = "1.15.3"
 ksp = "1.9.21-1.0.16"
+rgxgen = "2.0"
 # buildsrc and plugins
 snakeyaml = "2.2"
 plugin-dokka = "1.9.10"
@@ -20,7 +20,6 @@ kctfork = "0.4.1"
 [libraries]
 commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
-generex = { module = "com.github.mifmif:generex", version.ref = "generex" }
 icu4j = { module = "com.ibm.icu:icu4j", version.ref = "icu4j" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
@@ -31,6 +30,7 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 kotlinpoet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinpoet" }
 ksp = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
+rgxgen = { module = "com.github.curious-odd-man:rgxgen", version.ref = "rgxgen" }
 
 # Plugins and dependencies for use in buildSrc/build.gradle.kts
 # Plugins are the *Maven coodinates* of Gradle plugins.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ apply(from = "./buildSrc/repositories.settings.gradle.kts")
 
 plugins {
     // NB! remember to set same version in gradle/libs.versions.toml:10
-    id("io.github.serpro69.semantic-versioning") version "0.13.0"
+    id("io.github.serpro69.semantic-versioning") version "0.14.0"
 }
 
 rootProject.name = "kotlin-faker"


### PR DESCRIPTION
Generex is unmaintained and https://github.com/mifmif/Generex/issues/56 is unlikely to be fixed, which causes issues in kotlin-faker.

This PR will fix #207 and fix #209 