### PR TITLE
Add collection element and map k/v type gen for random class instance

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -81,17 +81,6 @@ jobs:
         echo '  make release'
         exit 1
 
-    # we need both because graal plugin in cli-bot requires jdk version >= 11
-    # more details in CONTRIBUTING
-    - name: Set up JDK 8 and 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: |
-          8
-          11
-          17
-        distribution: 'temurin'
-
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,8 +55,9 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3.25.0
+      uses: github/codeql-action/init@v3.25.6
       with:
+        tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.17.3/codeql-bundle-linux64.tar.gz
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -82,6 +83,7 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3.25.0
+      uses: github/codeql-action/analyze@v3.25.6
       with:
+        tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.17.3/codeql-bundle-linux64.tar.gz
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,5 +85,4 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3.25.6
       with:
-        tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.17.3/codeql-bundle-linux64.tar.gz
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -88,6 +88,7 @@ jobs:
       with:
         java-version: |
           8
+          11
           17
         distribution: 'temurin'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v3.25.0
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -82,6 +82,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v3.25.0
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -81,6 +81,16 @@ jobs:
         echo '  make release'
         exit 1
 
+    # we need both because graal plugin in cli-bot requires jdk version >= 11
+    # more details in CONTRIBUTING
+    - name: Set up JDK 8 and 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: |
+          8
+          17
+        distribution: 'temurin'
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -748,14 +748,15 @@ public final class io/github/serpro69/kfaker/provider/misc/RandomProvider$Key : 
 
 public final class io/github/serpro69/kfaker/provider/misc/RandomProviderConfig {
 	public fun <init> ()V
-	public final fun getCollectionTypeGenerators ()Ljava/util/Map;
+	public final fun getCollectionElementTypeGenerators ()Ljava/util/HashMap;
 	public final fun getCollectionsSize ()I
 	public final fun getConstructorFilterStrategy ()Lio/github/serpro69/kfaker/provider/misc/ConstructorFilterStrategy;
 	public final fun getConstructorParamSize ()I
 	public final fun getFallbackStrategy ()Lio/github/serpro69/kfaker/provider/misc/FallbackStrategy;
+	public final fun getMapEntriesTypeGenerators ()Lkotlin/Pair;
 	public final fun getNamedParameterGenerators ()Ljava/util/Map;
-	public final fun getNullableGenerators ()Ljava/util/Map;
-	public final fun getPredefinedGenerators ()Ljava/util/Map;
+	public final fun getNullableGenerators ()Ljava/util/HashMap;
+	public final fun getPredefinedGenerators ()Ljava/util/HashMap;
 	public final fun setCollectionsSize (I)V
 	public final fun setConstructorFilterStrategy (Lio/github/serpro69/kfaker/provider/misc/ConstructorFilterStrategy;)V
 	public final fun setConstructorParamSize (I)V

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -659,16 +659,20 @@ public final class io/github/serpro69/kfaker/provider/misc/FallbackStrategy : ja
 }
 
 public final class io/github/serpro69/kfaker/provider/misc/ParameterInfo {
-	public fun <init> (ILjava/lang/String;ZZ)V
+	public fun <init> (ILjava/lang/String;ZZLkotlin/reflect/KType;Lkotlin/reflect/KParameter$Kind;)V
 	public final fun component1 ()I
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Z
 	public final fun component4 ()Z
-	public final fun copy (ILjava/lang/String;ZZ)Lio/github/serpro69/kfaker/provider/misc/ParameterInfo;
-	public static synthetic fun copy$default (Lio/github/serpro69/kfaker/provider/misc/ParameterInfo;ILjava/lang/String;ZZILjava/lang/Object;)Lio/github/serpro69/kfaker/provider/misc/ParameterInfo;
+	public final fun component5 ()Lkotlin/reflect/KType;
+	public final fun component6 ()Lkotlin/reflect/KParameter$Kind;
+	public final fun copy (ILjava/lang/String;ZZLkotlin/reflect/KType;Lkotlin/reflect/KParameter$Kind;)Lio/github/serpro69/kfaker/provider/misc/ParameterInfo;
+	public static synthetic fun copy$default (Lio/github/serpro69/kfaker/provider/misc/ParameterInfo;ILjava/lang/String;ZZLkotlin/reflect/KType;Lkotlin/reflect/KParameter$Kind;ILjava/lang/Object;)Lio/github/serpro69/kfaker/provider/misc/ParameterInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getIndex ()I
+	public final fun getKind ()Lkotlin/reflect/KParameter$Kind;
 	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Lkotlin/reflect/KType;
 	public fun hashCode ()I
 	public final fun isOptional ()Z
 	public final fun isVararg ()Z

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -744,6 +744,7 @@ public final class io/github/serpro69/kfaker/provider/misc/RandomProvider$Key : 
 
 public final class io/github/serpro69/kfaker/provider/misc/RandomProviderConfig {
 	public fun <init> ()V
+	public final fun getCollectionTypeGenerators ()Ljava/util/Map;
 	public final fun getCollectionsSize ()I
 	public final fun getConstructorFilterStrategy ()Lio/github/serpro69/kfaker/provider/misc/ConstructorFilterStrategy;
 	public final fun getConstructorParamSize ()I

--- a/core/src/integration/kotlin/io/github/serpro69/kfaker/docs/Extras.kt
+++ b/core/src/integration/kotlin/io/github/serpro69/kfaker/docs/Extras.kt
@@ -61,7 +61,7 @@ class Extras : DescribeSpec({
                                 // generate random string elements for parameters of List<String> type
                                 randomListString()
                             } else {
-                                // generate random string elements for parameters of other Collection types (Set, Map)
+                                // generate random string elements for parameters of Set type
                                 randomString()
                             }
                         }
@@ -72,6 +72,21 @@ class Extras : DescribeSpec({
                     assertEquals(baz.set.all { it == "string" }, true)
                 }
 
+                it("should generate pre-configured map key/value pairs for constructor params") {
+                    fun randomKey() = "key"
+                    fun randomValue() = "value"
+                    // START extras_random_instance_seventeen
+                    class Baz(val map: Map<String, String>)
+
+                    val baz: Baz = faker.randomClass.randomClassInstance {
+                        mapEntryKeyTypeGenerator { randomKey() }
+                        mapEntryValueTypeGenerator { randomValue() }
+                    }
+                    // END extras_random_instance_seventeen
+
+                    assertEquals(baz.map.keys.all { it == "key" }, true)
+                    assertEquals(baz.map.values.all { it == "value" }, true)
+                }
             }
         }
 

--- a/core/src/integration/kotlin/io/github/serpro69/kfaker/docs/Extras.kt
+++ b/core/src/integration/kotlin/io/github/serpro69/kfaker/docs/Extras.kt
@@ -10,6 +10,7 @@ import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import java.util.*
+import kotlin.reflect.KClass
 
 class Extras : DescribeSpec({
     val faker = Faker()
@@ -43,6 +44,34 @@ class Extras : DescribeSpec({
                 assertEquals(baz.user, "user_X3a8s813dcb")
                 assertEquals(baz.uuid, UUID.fromString("00000000-0000-0000-0000-000000000000"))
                 assertEquals(baz.relatedUuid, UUID.fromString("11111111-1111-1111-1111-111111111111"))
+            }
+
+            context("collection element generation") {
+                it("should generate pre-configured collection elements for constructor params") {
+                    // START extras_random_instance_sixteen
+                    fun randomListString() = "list"
+                    fun randomString() = "string"
+
+                    class Baz(val list: List<String>, val set: Set<String>)
+
+                    val baz: Baz = faker.randomClass.randomClassInstance {
+                        collectionTypeGenerator<String> {
+                            // customize generators for different collection types
+                            if ((it.type.classifier as KClass<*>) == List::class) {
+                                // generate random string elements for parameters of List<String> type
+                                randomListString()
+                            } else {
+                                // generate random string elements for parameters of other Collection types (Set, Map)
+                                randomString()
+                            }
+                        }
+                    }
+                    // END extras_random_instance_sixteen
+
+                    assertEquals(baz.list.all { it == "list" }, true)
+                    assertEquals(baz.set.all { it == "string" }, true)
+                }
+
             }
         }
 
@@ -274,6 +303,7 @@ class Extras : DescribeSpec({
                 // END extras_random_instance_fifteen
             }
         }
+
     }
 
     describe("Random Everything") {

--- a/core/src/integration/kotlin/io/github/serpro69/kfaker/docs/Extras.kt
+++ b/core/src/integration/kotlin/io/github/serpro69/kfaker/docs/Extras.kt
@@ -55,7 +55,7 @@ class Extras : DescribeSpec({
                     class Baz(val list: List<String>, val set: Set<String>)
 
                     val baz: Baz = faker.randomClass.randomClassInstance {
-                        collectionTypeGenerator<String> {
+                        collectionElementTypeGenerator<String> {
                             // customize generators for different collection types
                             if ((it.type.classifier as KClass<*>) == List::class) {
                                 // generate random string elements for parameters of List<String> type

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/ParameterInfo.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/ParameterInfo.kt
@@ -1,6 +1,7 @@
 package io.github.serpro69.kfaker.provider.misc
 
 import kotlin.reflect.KParameter
+import kotlin.reflect.KType
 
 /**
  * Provides additional information about Class parameter to custom defined generators.
@@ -11,7 +12,9 @@ data class ParameterInfo(
     val index: Int,
     val name: String,
     val isOptional: Boolean,
-    val isVararg: Boolean
+    val isVararg: Boolean,
+    val type: KType,
+    val kind: KParameter.Kind,
 )
 
 /**
@@ -21,5 +24,7 @@ internal fun KParameter.toParameterInfo() = ParameterInfo(
     index = index,
     name = name.toString(),
     isOptional = isOptional,
-    isVararg = isVararg
+    isVararg = isVararg,
+    type = type,
+    kind = kind,
 )

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/ParameterInfo.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/ParameterInfo.kt
@@ -1,5 +1,6 @@
 package io.github.serpro69.kfaker.provider.misc
 
+import kotlin.reflect.KCallable
 import kotlin.reflect.KParameter
 import kotlin.reflect.KType
 
@@ -7,6 +8,33 @@ import kotlin.reflect.KType
  * Provides additional information about Class parameter to custom defined generators.
  * The reason why KParameter is not used is that you will want to provide
  * additional information about parameter that is not available in KParameter class.
+ *
+ * @property index 0-based index of this parameter in the parameter list of its containing callable.
+ *
+ * @property name Name of this parameter as it was declared in the source code,
+ * or `null` if the parameter has no name or its name is not available at runtime.
+ * Examples of nameless parameters include `this` instance for member functions,
+ * extension receiver for extension functions or properties, parameters of Java methods
+ * compiled without the debug information, and others.
+ *
+ * @property type Type of this parameter. For a `vararg` parameter, this is the type of the corresponding array,
+ * not the individual element.
+ *
+ * @property kind Kind of this parameter.
+ * Kind represents a particular position of the parameter declaration in the source code,
+ * such as an instance, an extension receiver parameter or a value parameter.
+ *
+ * @property isOptional
+ * `true` if this parameter is optional and can be omitted when making a call via [KCallable.callBy], or `false` otherwise.
+ *
+ * A parameter is optional in any of the two cases:
+ * 1. The default value is provided at the declaration of this parameter.
+ * 2. The parameter is declared in a member function and one of the corresponding parameters in the super functions is optional.
+ *
+ * @property isVararg
+ * `true` if this parameter is `vararg`.
+ * See the [Kotlin language documentation](https://kotlinlang.org/docs/reference/functions.html#variable-number-of-arguments-varargs)
+ * for more information.
  */
 data class ParameterInfo(
     val index: Int,
@@ -20,11 +48,12 @@ data class ParameterInfo(
 /**
  * Extension function that maps KParameter to ParameterInfo dataclass.
  */
-internal fun KParameter.toParameterInfo() = ParameterInfo(
-    index = index,
-    name = name.toString(),
-    isOptional = isOptional,
-    isVararg = isVararg,
-    type = type,
-    kind = kind,
-)
+internal fun KParameter.toParameterInfo() =
+    ParameterInfo(
+        index = index,
+        name = name.toString(),
+        isOptional = isOptional,
+        isVararg = isVararg,
+        type = type,
+        kind = kind,
+    )

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProvider.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProvider.kt
@@ -17,8 +17,10 @@ import kotlin.Long
 import kotlin.Short
 import kotlin.String
 import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
 import kotlin.reflect.KType
 import kotlin.reflect.KVisibility
+import kotlin.reflect.full.starProjectedType
 import kotlin.reflect.jvm.jvmName
 
 /**
@@ -126,7 +128,14 @@ class RandomClassProvider {
             predefinedTypeOrNull(
                 config,
                 // it's not a constructor parameter, so set some hardcoded values for ParameterInfo
-                ParameterInfo(index = -1, name = jvmName, isOptional = false, isVararg = false)
+                ParameterInfo(
+                    index = -1,
+                    name = jvmName,
+                    isOptional = false,
+                    isVararg = false,
+                    type = starProjectedType,
+                    kind = KParameter.Kind.INSTANCE
+                )
             ) as T?
         }
 

--- a/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProvider.kt
+++ b/core/src/main/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProvider.kt
@@ -398,8 +398,10 @@ private fun RandomProviderConfig.copy(
     constructorFilterStrategy: ConstructorFilterStrategy? = null,
     fallbackStrategy: FallbackStrategy? = null,
     namedParameterGenerators: Map<String, (pInfo: ParameterInfo) -> Any?>? = null,
-    predefinedGenerators: Map<KClass<*>, (pInfo: ParameterInfo) -> Any>? = null,
-    nullableGenerators: Map<KClass<*>, (pInfo: ParameterInfo) -> Any?>? = null
+    predefinedGenerators: TypeGenMap? = null,
+    nullableGenerators: NullableTypeGenMap? = null,
+    collectionElementTypeGenerators: NullableTypeGenMap? = null,
+    mapEntriesTypeGenerators: Pair<TypeGenMap, NullableTypeGenMap>? = null,
 ): RandomProviderConfig = RandomProviderConfig().apply {
     this@apply.collectionsSize = collectionsSize ?: this@copy.collectionsSize
     this@apply.constructorParamSize = constructorParamSize ?: this@copy.constructorParamSize
@@ -408,6 +410,9 @@ private fun RandomProviderConfig.copy(
     this@apply.namedParameterGenerators.putAll(namedParameterGenerators ?: this@copy.namedParameterGenerators)
     this@apply.predefinedGenerators.putAll(predefinedGenerators ?: this@copy.predefinedGenerators)
     this@apply.nullableGenerators.putAll(nullableGenerators ?: this@copy.nullableGenerators)
+    this@apply.collectionElementTypeGenerators.putAll(collectionElementTypeGenerators ?: this@copy.collectionElementTypeGenerators)
+    this@apply.mapEntriesTypeGenerators.first.putAll(mapEntriesTypeGenerators?.first ?: this@copy.mapEntriesTypeGenerators.first)
+    this@apply.mapEntriesTypeGenerators.second.putAll(mapEntriesTypeGenerators?.second ?: this@copy.mapEntriesTypeGenerators.second)
 }
 
 enum class FallbackStrategy {
@@ -422,5 +427,5 @@ enum class ConstructorFilterStrategy {
     MAX_NUM_OF_ARGS
 }
 
-typealias TypeGenMap = HashMap<KClass<*>, (pInfo: ParameterInfo) -> Any>
-typealias NullableTypeGenMap = HashMap<KClass<*>, (pInfo: ParameterInfo) -> Any?>
+internal typealias TypeGenMap = HashMap<KClass<*>, (pInfo: ParameterInfo) -> Any>
+internal typealias NullableTypeGenMap = HashMap<KClass<*>, (pInfo: ParameterInfo) -> Any?>

--- a/core/src/test/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProviderTest.kt
+++ b/core/src/test/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProviderTest.kt
@@ -5,6 +5,7 @@ import io.github.serpro69.kfaker.fakerConfig
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.channels.beEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.ints.shouldBeInRange
 import io.kotest.matchers.maps.shouldHaveSize
@@ -483,6 +484,14 @@ class RandomClassProviderTest : DescribeSpec({
             testClass.enumSet.all { it == TestEnum.GO } shouldBe true
             testClass.enumMap shouldHaveSize 1
             testClass.enumMap.all { it.value == TestEnum.GO } shouldBe true
+        }
+
+        it("typeGenerator should have precedence over collectionTypeGenerator") {
+            val testClass = randomProvider.randomClassInstance<TestClass> {
+                collectionTypeGenerator<Char> { 'c' }
+                typeGenerator<List<Char>> { listOf() }
+            }
+            testClass.charList shouldBe emptyList()
         }
     }
 

--- a/core/src/test/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProviderTest.kt
+++ b/core/src/test/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProviderTest.kt
@@ -225,7 +225,7 @@ class RandomClassProviderTest : DescribeSpec({
                 testClass.id shouldBe givenUuid
                 testClass.int shouldBe givenInt
                 testClass.foo.int shouldBe givenInt
-                testClass.bar shouldBe "ParameterInfo(index=0, name=bar, isOptional=false, isVararg=false)"
+                testClass.bar shouldBe "ParameterInfo(index=0, name=bar, isOptional=false, isVararg=false, type=kotlin.String, kind=VALUE)"
             }
         }
     }
@@ -258,7 +258,7 @@ class RandomClassProviderTest : DescribeSpec({
                 testClass.id2 shouldBe typeGeneratedId
                 testClass.nullableId shouldBe nullableNamedParameterGeneratedId
                 testClass.nullableId2 shouldBe null
-                testClass.foo shouldBe "ParameterInfo(index=4, name=foo, isOptional=true, isVararg=false)"
+                testClass.foo shouldBe "ParameterInfo(index=4, name=foo, isOptional=true, isVararg=false, type=kotlin.String?, kind=VALUE)"
             }
         }
     }

--- a/core/src/test/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProviderTest.kt
+++ b/core/src/test/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProviderTest.kt
@@ -789,6 +789,11 @@ class RandomClassProviderTest : DescribeSpec({
                     typeGenerator { "42" }
                     typeGenerator { 42 }
                     typeGenerator { 42.0 }
+                    nullableTypeGenerator<String> { null }
+                    namedParameterGenerator("foo") { "bar" }
+                    collectionElementTypeGenerator { 36 }
+                    mapEntryKeyTypeGenerator { 0 }
+                    mapEntryValueTypeGenerator { 1 }
                 }
                 val copy = copy()
                 configProperties(copy.config) shouldBe configProperties(this@with.config)

--- a/core/src/test/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProviderTest.kt
+++ b/core/src/test/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProviderTest.kt
@@ -461,36 +461,47 @@ class RandomClassProviderTest : DescribeSpec({
             val bar = Bar(42)
             val baz = Baz(foo, "foo")
             val testClass = randomProvider.randomClassInstance<TestClass> {
-                collectionTypeGenerator<Foo> { foo }
-                collectionTypeGenerator<Bar> { bar }
-                collectionTypeGenerator<Baz> { baz }
-                collectionTypeGenerator<String> { "string" }
-                collectionTypeGenerator<Char> { 'c' }
-                collectionTypeGenerator<Boolean> { true }
-                collectionTypeGenerator<Int> { 42 }
-                collectionTypeGenerator<Byte> { Byte.MAX_VALUE }
-                collectionTypeGenerator<TestEnum> { TestEnum.GO }
+                collectionElementTypeGenerator<Foo> { foo }
+                collectionElementTypeGenerator<Bar> { bar }
+                mapEntryKeyTypeGenerator<String> { "map" }
+                mapEntryValueTypeGenerator<Baz> { baz }
+                collectionElementTypeGenerator<String> { "string" }
+                collectionElementTypeGenerator<Char> { 'c' }
+                collectionElementTypeGenerator<Boolean> { true }
+                collectionElementTypeGenerator<Int> { 42 }
+                collectionElementTypeGenerator<Byte> { Byte.MAX_VALUE }
+                mapEntryKeyTypeGenerator<Boolean> { false }
+                mapEntryValueTypeGenerator<Byte> { Byte.MAX_VALUE }
+                collectionElementTypeGenerator<TestEnum> { TestEnum.GO }
+                mapEntryKeyTypeGenerator<TestEnum> { TestEnum.JAVA }
+                mapEntryValueTypeGenerator<TestEnum> { TestEnum.KOTLIN }
             }
             testClass.set shouldHaveSize 1
             testClass.set.first() shouldBe bar
-            testClass.map.all { it.value == baz } shouldBe true
+            testClass.map.all { it.key == "map" && it.value == baz } shouldBe true
             testClass.charList.all { it == 'c' } shouldBe true
             testClass.intSet shouldHaveSize 1
             testClass.intSet.first() shouldBe 42
-            testClass.boolMap.all { it.value == Byte.MAX_VALUE } shouldBe true
+            testClass.boolMap.all { !it.key && it.value == Byte.MAX_VALUE } shouldBe true
             testClass.enumList.all { it == TestEnum.GO } shouldBe true
             testClass.enumSet shouldHaveSize 1
             testClass.enumSet.all { it == TestEnum.GO } shouldBe true
-            testClass.enumMap shouldHaveSize 1
-            testClass.enumMap.all { it.value == TestEnum.GO } shouldBe true
+            testClass.enumMap.keys.all { it == TestEnum.JAVA } shouldBe true
+            testClass.enumMap.values.all { it == TestEnum.KOTLIN } shouldBe true
         }
 
-        it("typeGenerator should have precedence over collectionTypeGenerator") {
+        it("typeGenerator should have precedence over collection and map generators") {
             val testClass = randomProvider.randomClassInstance<TestClass> {
-                collectionTypeGenerator<Char> { 'c' }
-                typeGenerator<List<Char>> { listOf() }
+                collectionElementTypeGenerator<TestEnum> { TestEnum.JAVA }
+                mapEntryKeyTypeGenerator<TestEnum> { TestEnum.KOTLIN }
+                mapEntryValueTypeGenerator<TestEnum> { TestEnum.GO }
+                typeGenerator<List<TestEnum>> { TestEnum.entries }
+                typeGenerator<Set<TestEnum>> { emptySet() }
+                typeGenerator<Map<TestEnum, TestEnum>> { mapOf(TestEnum.JAVA to TestEnum.KOTLIN) }
             }
-            testClass.charList shouldBe emptyList()
+            testClass.enumList shouldBe TestEnum.entries
+            testClass.enumSet shouldBe emptySet()
+            testClass.enumMap shouldBe mapOf(TestEnum.JAVA to TestEnum.KOTLIN)
         }
     }
 

--- a/core/src/test/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProviderTest.kt
+++ b/core/src/test/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProviderTest.kt
@@ -5,7 +5,6 @@ import io.github.serpro69.kfaker.fakerConfig
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.channels.beEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.ints.shouldBeInRange
 import io.kotest.matchers.maps.shouldHaveSize

--- a/core/src/test/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProviderTest.kt
+++ b/core/src/test/kotlin/io/github/serpro69/kfaker/provider/misc/RandomClassProviderTest.kt
@@ -14,7 +14,8 @@ import io.kotest.matchers.string.shouldHaveLength
 import io.kotest.matchers.types.instanceOf
 import io.kotest.matchers.types.shouldNotBeSameInstanceAs
 import org.junit.jupiter.api.assertThrows
-import java.util.*
+import java.util.Random
+import java.util.UUID
 import kotlin.reflect.full.declaredMemberProperties
 
 @Suppress("unused")
@@ -437,6 +438,7 @@ class RandomClassProviderTest : DescribeSpec({
             // enum-key based map can only have up to 3 entries in this case, depending on the randomness of the generated key
             testClass.enumMap.size shouldBeInRange 1..3
         }
+
         it("should generate Collections with pre-configured type generation") {
             val testClass = randomProvider.randomClassInstance<TestClass> {
                 typeGenerator<List<Foo>> { listOf() }
@@ -452,6 +454,35 @@ class RandomClassProviderTest : DescribeSpec({
             testClass.enumList shouldHaveSize 0
             testClass.enumSet shouldHaveSize 1
             testClass.enumMap shouldHaveSize 1
+        }
+
+        it("should generate elements in a collection with predefined collection generator") {
+            val foo = Foo()
+            val bar = Bar(42)
+            val baz = Baz(foo, "foo")
+            val testClass = randomProvider.randomClassInstance<TestClass> {
+                collectionTypeGenerator<Foo> { foo }
+                collectionTypeGenerator<Bar> { bar }
+                collectionTypeGenerator<Baz> { baz }
+                collectionTypeGenerator<String> { "string" }
+                collectionTypeGenerator<Char> { 'c' }
+                collectionTypeGenerator<Boolean> { true }
+                collectionTypeGenerator<Int> { 42 }
+                collectionTypeGenerator<Byte> { Byte.MAX_VALUE }
+                collectionTypeGenerator<TestEnum> { TestEnum.GO }
+            }
+            testClass.set shouldHaveSize 1
+            testClass.set.first() shouldBe bar
+            testClass.map.all { it.value == baz } shouldBe true
+            testClass.charList.all { it == 'c' } shouldBe true
+            testClass.intSet shouldHaveSize 1
+            testClass.intSet.first() shouldBe 42
+            testClass.boolMap.all { it.value == Byte.MAX_VALUE } shouldBe true
+            testClass.enumList.all { it == TestEnum.GO } shouldBe true
+            testClass.enumSet shouldHaveSize 1
+            testClass.enumSet.all { it == TestEnum.GO } shouldBe true
+            testClass.enumMap shouldHaveSize 1
+            testClass.enumMap.all { it.value == TestEnum.GO } shouldBe true
         }
     }
 

--- a/docs/src/orchid/resources/wiki/extras.md
+++ b/docs/src/orchid/resources/wiki/extras.md
@@ -252,7 +252,7 @@ A random class instance will be generated using the following precedence rules:
 
 #### Predefined collection element types
 
-It may be desirable to define how elements in a collection parameter are generated, for this `collectionTypeGenerator` function can be used:
+It may be desirable to define how elements in a collection parameter are generated, for this `collectionElementTypeGenerator` function can be used:
 
 {% tabs %}
 

--- a/docs/src/orchid/resources/wiki/extras.md
+++ b/docs/src/orchid/resources/wiki/extras.md
@@ -10,6 +10,9 @@
 * [Random instance of any class](#random-instance-of-any-class)
   * [Random Class Instance Configuration](#random-class-instance-configuration)
   * [Pre-configuring type generation](#pre-configuring-type-generation)
+    * [Predefined types for constructor parameters](#predefined-types-for-constructor-parameters)
+    * [Pre-defined instance for classes with no public constructors](#pre-defined-instance-for-classes-with-no-public-constructors)
+    * [Predefined collection element types](#predefined-collection-element-types)
   * [Deterministic constructor selection](#deterministic-constructor-selection)
   * [Configuring the size of generated Collections](#configuring-the-size-of-generated-collections)
   * [Making a Copy or a New instance of RandomClassProvider](#making-a-new-instance-of-random-class-provider)
@@ -244,6 +247,43 @@ A random class instance will be generated using the following precedence rules:
 - failing all of the above, `NoSuchElementException` will be thrown
 
 {% btc %}{% endbtc %}
+
+<br>
+
+#### Predefined collection element types
+
+It may be desirable to define how elements in a collection parameter are generated, for this `collectionTypeGenerator` function can be used:
+
+{% tabs %}
+
+{% kotlin "Kotlin" %}
+{% filter compileAs('md') %}
+```kotlin
+{% snippet 'extras_random_instance_sixteen' %}
+```
+{% endfilter %}
+{% endkotlin %}
+
+{% endtabs %}
+
+<br>
+
+So for each instance of `Baz` the following will be true:
+
+```kotlin
+baz.list.all { it == "list" }
+baz.set.all {it == "string" }
+```
+
+This example kind of makes little sense, since we're using "static" values, so it's just for example purposes.
+
+{% info %}
+{% filter compileAs('md') %}
+Note how we can use `it.type.classifier` to figure out the parameter classifier and further customize generation for different collection types.
+
+Explore other properties of `it`, which exposes more details about the [parameter](https://serpro69.github.io/kotlin-faker/kotlindoc/core-api/io/github/serpro69/kfaker/provider/misc/parameterinfo/) that is being customized.
+{% endfilter %}
+{% endinfo %}
 
 <br>
 

--- a/docs/src/orchid/resources/wiki/extras.md
+++ b/docs/src/orchid/resources/wiki/extras.md
@@ -252,7 +252,7 @@ A random class instance will be generated using the following precedence rules:
 
 #### Predefined collection element types
 
-It may be desirable to define how elements in a collection parameter are generated, for this `collectionElementTypeGenerator` function can be used:
+It may be desirable to define how elements of a `Collection` (currently supports `List`s and `Set`s) constructor parameter type are generated, for this `collectionElementTypeGenerator` function can be used:
 
 {% tabs %}
 
@@ -284,6 +284,20 @@ Note how we can use `it.type.classifier` to figure out the parameter classifier 
 Explore other properties of `it`, which exposes more details about the [parameter](https://serpro69.github.io/kotlin-faker/kotlindoc/core-api/io/github/serpro69/kfaker/provider/misc/parameterinfo/) that is being customized.
 {% endfilter %}
 {% endinfo %}
+
+There are also two similar methods for map entries: `mapEntryKeyTypeGenerator` and `mapEntryValueTypeGenerator`, which can be used to configure how keys and values are generated in `Map` constructor parameter types:
+
+{% tabs %}
+
+{% kotlin "Kotlin" %}
+{% filter compileAs('md') %}
+```kotlin
+{% snippet 'extras_random_instance_seventeen' %}
+```
+{% endfilter %}
+{% endkotlin %}
+
+{% endtabs %}
 
 <br>
 


### PR DESCRIPTION
Fix #242 

TODO:
- [x] update docs
- [x] in case of maps, do we want to be able to predefine generators for keys as well? (I can see this _not_ being very useful and even harmful sometimes, e.g. when k/v are the same type like String)
  - [x] try if we can make it "parameterized" and allow the user to specify whether they want to generate keys, values or both in a Map